### PR TITLE
Check for no_std gated by not(test)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ matrix:
     # - env: TARGET=thumbv7m-none-eabi
 
     # Testing other channels
-    # Until issue #37 is fixed, disable linux targets
+    # Until issue #37 is fixed, disable linux targets.
+    # Test failed CI due to file locking error, try again
     #- env: TARGET=x86_64-unknown-linux-gnu
     #  rust: nightly
     - env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ matrix:
     # - env: TARGET=powerpc64-unknown-linux-gnu
     # - env: TARGET=powerpc64le-unknown-linux-gnu
     # - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-linux-gnu
+    # Until issue #37 is fixed, disable linux targets
+    # - env: TARGET=x86_64-unknown-linux-gnu
     # - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
@@ -60,8 +61,9 @@ matrix:
     # - env: TARGET=thumbv7m-none-eabi
 
     # Testing other channels
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
+    # Until issue #37 is fixed, disable linux targets
+    #- env: TARGET=x86_64-unknown-linux-gnu
+    #  rust: nightly
     - env: TARGET=x86_64-apple-darwin
       os: osx
       rust: nightly

--- a/src/check_source.rs
+++ b/src/check_source.rs
@@ -223,7 +223,11 @@ fn check_source(source_path: &PathBuf, is_main_file: bool) -> CrateSupport {
         let always_no_std: syn::Attribute = syn::parse_quote!(#![no_std]);
         let contains_always_no_std = syntax.attrs.contains(&always_no_std);
         if !contains_always_no_std {
-            offenses.push(SourceOffense::MissingNoStdAttribute);
+            let not_test_no_std: syn::Attribute = syn::parse_quote!(#![cfg_attr(not(test), no_std)]);
+            let contains_not_test_no_std = syntax.attrs.contains(&not_test_no_std);
+            if !contains_not_test_no_std {
+                offenses.push(SourceOffense::MissingNoStdAttribute);
+            }
         }
     }
 

--- a/tests/crate_itself_not_test_no_std.rs
+++ b/tests/crate_itself_not_test_no_std.rs
@@ -1,0 +1,33 @@
+extern crate assert_cmd;
+
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+mod crate_itself_not_test_no_std {
+    use super::*;
+
+    #[test]
+    fn it_succeeds() {
+        Command::main_binary()
+            .unwrap()
+            .arg("check")
+            .current_dir("./tests/crate_itself_not_test_no_std")
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn it_prints_checkmark() {
+    let output = Command::main_binary()
+        .unwrap()
+        .arg("check")
+        .current_dir("./tests/crate_itself_not_test_no_std")
+        .output()
+        .unwrap()
+        .stdout;
+    let output = String::from_utf8(output).unwrap();
+
+    let expected_cause = "crate_itself_not_test_no_std: SUCCESS";
+    assert!(output.contains(expected_cause));
+}

--- a/tests/crate_itself_not_test_no_std/Cargo.toml
+++ b/tests/crate_itself_not_test_no_std/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "crate_itself_not_test_no_std"
+version = "0.1.0"
+authors = ["Joey Yandle <xoloki@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/tests/crate_itself_not_test_no_std/src/main.rs
+++ b/tests/crate_itself_not_test_no_std/src/main.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
The no_std check in main files does not catch the case where the no_std is gated on not(test).  This change adds that check before failing with SourceOffense::MissingNoStdAttribute.

This fixes a false positive with the widely used clear_on_drop crate, which prevents using cargo nono in CI for crates which depend on clear_on_drop.
