### PR TITLE
Fixes #46, fixes #22

### DIFF
--- a/src/check_source.rs
+++ b/src/check_source.rs
@@ -130,7 +130,7 @@ impl fmt::Display for UseStdStmt {
             src = self
                 .src_path
                 .strip_prefix(std::env::current_dir().unwrap())
-                .unwrap()
+                .unwrap_or(&self.src_path)
                 .display(),
         )
     }


### PR DESCRIPTION
Just display the complete path if not based in the current repo.