### PR TITLE
Fix typo in suggested conditional attribute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn check_and_print_package(
         for offense in offenses {
             match offense {
                 SourceOffense::MissingNoStdAttribute => {
-                    println!("  - Did not find a #![no_std] attribute or a simple conditional attribute like #[cfg_attr(not(feature = \"std\"), no_std)] in the crate source. Crate most likely doesn't support no_std without changes.");
+                    println!("  - Did not find a #![no_std] attribute or a simple conditional attribute like #![cfg_attr(not(feature = \"std\"), no_std)] in the crate source. Crate most likely doesn't support no_std without changes.");
                 }
                 SourceOffense::UseStdStatement(stmt) => {
                     println!("  - Source code contains an explicit `use std::` statement.");


### PR DESCRIPTION
Attempted to just copy the suggested `#[cfg_attr(not(feature = "std"), no_std)]` to my `lib.rs`, but it didn't work. Turned out a `!` was missing after the `#`.