### PR TITLE
Add error message when fetching metadata fails

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,8 @@ pub fn metadata_run(additional_args: Option<String>) -> Result<Metadata, ()> {
 
     let output = cmd.output().unwrap();
     let stdout = from_utf8(&output.stdout).unwrap();
-    let meta = serde_json::from_str(stdout).unwrap();
+    let meta = serde_json::from_str(stdout)
+        .expect("Fetching metadata failed. Please call cargo-nono from within a cargo project.");
     Ok(meta)
 }
 


### PR DESCRIPTION
this can happen when starting cargo-nono from a non-cargo directory