### PR TITLE
Add (repeatable) --allow <crate> option

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -11,6 +11,7 @@ pub enum CrateSupport {
     ProcMacro,
     SourceOffenses(Vec<SourceOffense>),
     NoOffenseDetected,
+    Skipped,
 }
 
 #[derive(Debug)]
@@ -94,6 +95,7 @@ impl CheckResult {
             CrateSupport::OnlyWithoutFeature(ref feature) => !self.is_feature_active(feature),
             CrateSupport::NoOffenseDetected => true,
             CrateSupport::SourceOffenses(_) => false,
+            CrateSupport::Skipped => true,
         }
     }
 

--- a/src/check_source.rs
+++ b/src/check_source.rs
@@ -145,6 +145,7 @@ pub fn get_crate_support_from_source(main_src_path: &PathBuf) -> CrateSupport {
         CrateSupport::ProcMacro => return main_file_support,
         CrateSupport::SourceOffenses(mut off) => offenses.append(&mut off),
         CrateSupport::NoOffenseDetected => {}
+        CrateSupport::Skipped => return main_file_support,
     };
 
     let other_source_files_pattern = format!(


### PR DESCRIPTION
While there are still crates whose no_std status isn't correctly
determined, it's useful to be able manually allow specific crates
that are known to be no_std.